### PR TITLE
V3 Compatibility Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <script src="http://kendo.cdn.telerik.com/2016.1.226/js/jszip.min.js"></script>
     <script src="http://kendo.cdn.telerik.com/2016.1.226/js/kendo.all.min.js"></script>
     <script src="http://kendo.cdn.telerik.com/2016.1.226/js/kendo.aspnetmvc.min.js"></script>
-    <script src="/lib/o.js/o.js"></script>
     <script src="/static/kendo.data.odata-batch.js"></script>
   </head>
   <body>

--- a/kendo.data.odata-batch.js
+++ b/kendo.data.odata-batch.js
@@ -1,197 +1,199 @@
 (function ($, kendo) {
-  function pack(data, boundary) {
-    var body = [];
-    var changeset = kendo.guid();
+    function pack(data, boundary) {
+        var body = [];
+        var changeset = kendo.guid();
 
-    body.push('--batch_' + boundary);
-    body.push('Content-Type: multipart/mixed; boundary=changeset_' + changeset, '');
+        body.push('--batch_' + boundary);
+        body.push('Content-Type: multipart/mixed; boundary=changeset_' + changeset, '');
 
-    $.each(data, function (i, d) {
-      var t = d.type.toUpperCase(), noBody = ['GET', 'DELETE'];
+        $.each(data, function (i, d) {
+            var t = d.type.toUpperCase(), noBody = ['GET', 'DELETE'];
 
-      body.push('--changeset_' + changeset);
-      body.push('Content-Type: application/http');
-      body.push('Content-Transfer-Encoding: binary');
-      body.push('Content-ID:' + i + 1, '');
+            body.push('--changeset_' + changeset);
+            body.push('Content-Type: application/http');
+            body.push('Content-Transfer-Encoding: binary');
+            body.push('Content-ID:' + i + 1, '');
 
-      body.push(t + ' ' + d.url + ' HTTP/1.1');
+            body.push(t + ' ' + d.url + ' HTTP/1.1');
 
-      /* Don't care about content type for requests that have no body. */
-      if (noBody.indexOf(t) < 0) {
-        body.push('Content-Type: ' + (d.contentType || 'application/json; charset=utf-8'));
-        body.push('Accept: ' + (d.contentType || 'application/json; charset=utf-8'));
-      }
+            /* Don't care about content type for requests that have no body. */
+            if (noBody.indexOf(t) < 0) {
+                body.push('Content-Type: ' + (d.contentType || 'application/json; charset=utf-8'));
+                body.push('Accept: ' + (d.contentType || 'application/json; charset=utf-8'));
+            }
 
-      body.push('Host: ' + location.host);
-      body.push('', d.data ? JSON.stringify(d.data) : '');
-    });
+            body.push('Host: ' + location.host);
+            body.push('', d.data ? JSON.stringify(d.data) : '');
+        });
 
-    body.push('--changeset_' + changeset + '--', '');
-    body.push('--batch_' + boundary + '--', '');
+        body.push('--changeset_' + changeset + '--', '');
+        body.push('--batch_' + boundary + '--', '');
 
-    return body.join('\r\n');
-  }
-
-  function unpack (xhr, status, complete) {
-    var response = xhr.responseText;
-
-    var boundary = '--' + /boundary=(.*)/.exec(response)[1];
-
-    var payload = response.substring(response.indexOf(boundary))
-
-    payload = $.trim(payload.substring(0, payload.indexOf(boundary + '--')))
-
-    var responses = payload.split(boundary);
-
-    var data = [];
-
-    responses.forEach(function(response) {
-      var lines = response.split('\r\n\r\n');
-
-      if (lines.length > 1) {
-        var item = {
-          data: null
-        };
-
-        item.status = parseInt((function (m) {
-          return m || [0, 0];
-        })(/HTTP\/1.1 ([0-9]+)/g.exec(lines[1]))[1], 10);
-
-        if (item.status >= 400) {
-          status = 'error';
-        }
-
-        try {
-          item.data = JSON.parse(lines[2])
-        } catch (error) {
-          item.data = lines[2];
-        }
-
-        data.push(item)
-      }
-    });
-
-    complete.call(this, xhr, status, data);
-  }
-
-  function ajaxBatch(params) {
-    var boundary = kendo.guid();
-
-    $.ajax({
-      type: 'POST',
-      url: params.url,
-      data: pack(params.data, boundary),
-      contentType: 'multipart/mixed; boundary=batch_' + boundary,
-      complete: params.complete ?
-        function (xnr, status) { unpack(xnr, status, params.complete); } :
-          null
-    });
-  }
-
-  var odata = kendo.data.transports['odata-v4'];
-
-  function enqueue(items, verb, url, type) {
-    return items.map(function(item) {
-      if (type) {
-        item['odata.type'] = type;
-      }
-
-      return {
-        data: item,
-        type: verb,
-        url: typeof url == 'function' ? url(item) : url
-      }
-    });
-  }
-
-  function submit(e) {
-    var requests = [].concat(
-      enqueue(e.data.created, 'POST', this.options.create.url, this.options.type),
-      enqueue(e.data.updated, 'PUT', this.options.update.url, this.options.type),
-      enqueue(e.data.destroyed, 'DELETE', this.options.destroy.url)
-    );
-
-    var batchUrl = this.options.batchUrl || this.options.read.url.substring(0, this.options.read.url.lastIndexOf('/')) + '/$batch'
-
-    ajaxBatch({
-      url: batchUrl,
-      data: requests,
-      complete: function(xhr, status, response) {
-        if (status == 'success') {
-          var create = response.filter(function(item) {
-            return item.status == 201;
-          }).map(function(item) {
-            return item.data;
-          })
-
-          e.success(create, 'create');
-          e.success([], "update");
-          e.success([], "destroy");
-        } else {
-          e.error(response);
-        }
-      }
-    })
-  }
-
-  kendo.data.transports['odata-v4'] = kendo.data.RemoteTransport.extend({
-    init: function(options) {
-      kendo.data.RemoteTransport.fn.init.call(this, $.extend({}, odata, options));
-    },
-    submit: submit
-  });
-
-  function data(d) {
-    var data = d.value || d;
-
-    if (!$.isArray(data)) {
-      data = [data];
+        return body.join('\r\n');
     }
 
-    return data.map(strip);
-  }
+    function unpack(xhr, status, complete) {
+        var response = xhr.responseText;
 
-  function strip(item) {
-    var clone = {};
+        var boundary = '--' + /boundary=(.*)/.exec(response)[1];
 
-    for (var key in item) {
-      if (key.indexOf('odata') >= 0) {
-        continue;
-      }
+        var payload = response.substring(response.indexOf(boundary))
 
-      clone[key] = item[key];
+        payload = $.trim(payload.substring(0, payload.indexOf(boundary + '--')))
+
+        var responses = payload.split(boundary);
+
+        var data = [];
+
+        responses.forEach(function (response) {
+            var lines = response.split('\r\n\r\n');
+
+            if (lines.length > 1) {
+                var item = {
+                    data: null
+                };
+
+                item.status = parseInt((function (m) {
+                    return m || [0, 0];
+                })(/HTTP\/1.1 ([0-9]+)/g.exec(lines[1]))[1], 10);
+
+                if (item.status >= 400) {
+                    status = 'error';
+                }
+
+                try {
+                    item.data = JSON.parse(lines[2])
+                } catch (error) {
+                    item.data = lines[2];
+                }
+
+                data.push(item)
+            }
+        });
+
+        complete.call(this, xhr, status, data);
     }
 
-    return clone;
-  }
+    function ajaxBatch(params) {
+        var boundary = kendo.guid();
 
-  kendo.data.schemas['odata-v4'].data = data;
+        $.ajax({
+            type: 'POST',
+            url: params.url,
+            data: pack(params.data, boundary),
+            contentType: 'multipart/mixed; boundary=batch_' + boundary,
+            complete: params.complete ?
+              function (xnr, status) { unpack(xnr, status, params.complete); } :
+                null
+        });
+    }
 
-  kendo.data.transports['odata-v3'] = kendo.data.RemoteTransport.extend({
-    init: function(options) {
-      kendo.data.RemoteTransport.fn.init.call(this, $.extend({}, odata, options, {
-        parameterMap: this.parameterMap
-      }));
-    },
-    submit: submit,
-    parameterMap: function(options, type) {
-      var result = odata.parameterMap(options, type);
+    var odata = kendo.data.transports['odata'];
+    var odata4 = kendo.data.transports['odata-v4'];
 
-      if (type == 'read') {
-        if (result['$count'] == true) {
-          delete result['$count'];
-          result['$inlinecount'] = 'allpages';
+    function enqueue(items, verb, url, type) {
+        return items.map(function (item) {
+            if (type) {
+                item['odata.type'] = type;
+            }
+
+            return {
+                data: item,
+                type: verb,
+                url: typeof url == 'function' ? url(item) : url
+            }
+        });
+    }
+
+    function submit(e) {
+        var requests = [].concat(
+          enqueue(e.data.created, 'POST', this.options.create.url, this.options.type),
+          enqueue(e.data.updated, 'PUT', this.options.update.url, this.options.type),
+          enqueue(e.data.destroyed, 'DELETE', this.options.destroy.url)
+        );
+
+        var batchUrl = this.options.batchUrl || this.options.read.url.substring(0, this.options.read.url.lastIndexOf('/')) + '/$batch'
+
+        ajaxBatch({
+            url: batchUrl,
+            data: requests,
+            complete: function (xhr, status, response) {
+                if (status == 'success') {
+                    var create = response.filter(function (item) {
+                        return item.status == 201;
+                    }).map(function (item) {
+                        return item.data;
+                    })
+
+                    e.success(create, 'create');
+                    e.success([], "update");
+                    e.success([], "destroy");
+                } else {
+                    e.error(response);
+                }
+            }
+        })
+    }
+
+    function data(d) {
+        var data = d.value || d;
+
+        if (!$.isArray(data)) {
+            data = [data];
         }
-      }
 
-      return result;
+        return data.map(strip);
     }
-  });
 
-  kendo.data.schemas['odata-v3'] = {
-    data: data,
-    total: function(d) {
-      return Number(d['odata.count']);
+    function strip(item) {
+        var clone = {};
+
+        for (var key in item) {
+            if (key.indexOf('odata') >= 0) {
+                continue;
+            }
+
+            clone[key] = item[key];
+        }
+
+        return clone;
     }
-  };
+
+    kendo.data.transports['odata-v4'] = kendo.data.RemoteTransport.extend({
+        init: function (options) {
+            kendo.data.RemoteTransport.fn.init.call(this, $.extend({}, odata4, options));
+        },
+        submit: submit
+    });
+
+    kendo.data.schemas['odata-v4'].data = data;
+
+    kendo.data.transports['odata'] = kendo.data.RemoteTransport.extend({
+        init: function (options) {
+            kendo.data.RemoteTransport.fn.init.call(this, $.extend({}, odata, options, {
+                parameterMap: this.parameterMap
+            }));
+        },
+        submit: submit,
+        parameterMap: function (options, type) {
+            var result = odata.parameterMap(options, type);
+
+            if (type == 'read') {
+                if (result['$count'] == true) {
+                    delete result['$count'];
+                    result['$inlinecount'] = 'allpages';
+                }
+            }
+
+            return result;
+        }
+    });
+
+    kendo.data.schemas['odata'] = {
+        type: 'json',
+        data: data,
+        total: function (d) {
+            return Number(d['odata.count']);
+        }
+    };
 })(jQuery, kendo);


### PR DESCRIPTION
- Removed o.js from the sample HTML.
- Reorganized the code in the JS to have the transports and schemas modified last.
- Ctrl+K, Ctrl+D in Visual Studio (sorry)
- Changed the OData V3 moniker to "odata"
- Line 91 + 92 makes sure each of our changes are based on the corresponding original transports. Your version based both V3 and V4 on the V4 transport, which was throwing an error in my app.
